### PR TITLE
ffmpeg demuxer: refactoring for fast channel change

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -725,84 +725,12 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
     }
     else
     {
-      AVStream *stream = m_pFormatContext->streams[m_pkt.pkt.stream_index];
-
-      AVStream *st = m_pFormatContext->streams[m_pkt.pkt.stream_index];
-      // Fast udp/mpegts startup and channel switching.
-      // Set streaminfo false to skip avformat_find_stream_info (slow)
-      // But we do need a proper codec extradata so fill it in for ffmpeg.
-      // The idea is to detect an IDR: SPS + PPS + frame which can be decoded.
-      // This block is not entered if we already split extradata.
-      // This routine is based on avformat_find_stream_info and friends.
-      if(st->parser && st->parser->parser->split && !st->codec->extradata)
+      if (!m_streaminfo)
       {
-        int i = st->parser->parser->split(st->codec, m_pkt.pkt.data, m_pkt.pkt.size);
-        if (i > 0 && i < FF_MAX_EXTRADATA_SIZE)
-        {
-          // Found extradata, fill it in. This will cause
-          // a new stream to be created and used.
-          st->codec->extradata_size = i;
-          st->codec->extradata = (uint8_t*)m_dllAvUtil.av_malloc(st->codec->extradata_size + FF_INPUT_BUFFER_PADDING_SIZE);
-          if (st->codec->extradata)
-          {
-            CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::Read() fetching extradata, extradata_size(%d)", st->codec->extradata_size);
-            memcpy(st->codec->extradata, m_pkt.pkt.data, st->codec->extradata_size);
-            memset(st->codec->extradata + i, 0, FF_INPUT_BUFFER_PADDING_SIZE);
-
-            if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO)
-            {
-              const AVCodec* codec;
-              AVDictionary *thread_opt = NULL;
-              codec = st->codec->codec ? st->codec->codec : m_dllAvCodec.avcodec_find_decoder(st->codec->codec_id);
-              // Force thread count to 1 since the h264 decoder will not extract
-              // SPS and PPS to extradata during multi-threaded decoding
-              m_dllAvUtil.av_dict_set(&thread_opt, "threads", "1", 0);
-              m_dllAvCodec.avcodec_open2(st->codec, codec, &thread_opt);
-
-              // We don't need to actually decode here
-              st->codec->skip_idct = AVDISCARD_ALL;
-              st->codec->skip_frame = AVDISCARD_ALL;
-              st->codec->skip_loop_filter = AVDISCARD_ALL;
-
-              // This assumes that the current ffmpeg pkt contains a key_frame
-              AVFrame picture;
-              memset(&picture, 0, sizeof(AVFrame));
-              picture.pts = picture.pkt_dts = picture.pkt_pts = picture.best_effort_timestamp = AV_NOPTS_VALUE;
-              picture.pkt_pos = -1;
-              picture.key_frame = 1;
-              picture.format = -1;
-
-              int rtn, got_picture = 0;
-              rtn = m_dllAvCodec.avcodec_decode_video2(st->codec, &picture, &got_picture, &m_pkt.pkt);
-              if (rtn < 0)
-              {
-                CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::Read() decode failed (return value=%d)", rtn);
-                // Clear the extradata to allow entering this extradata section again
-                m_dllAvUtil.av_free(st->codec->extradata);
-                st->codec->extradata = NULL;
-                st->codec->extradata_size = 0;
-              }
-
-              m_dllAvCodec.avcodec_close(st->codec);
-              m_dllAvUtil.av_dict_free(&thread_opt);
-
-              st->parser->flags = 0;
-              int has_codec_parameters = st->codec->width && st->codec->pix_fmt != PIX_FMT_NONE;
-              //CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::Read() rtn(%d), got_picture(%d), has_codec_parameters(%d)", rtn, got_picture, has_codec_parameters);
-
-              if (!has_codec_parameters)
-              {
-                pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
-                return pPacket;
-              }
-            }
-          }
-          else
-          {
-            st->codec->extradata_size = 0;
-          }
-        }
+        GetStreamInfo(&m_pkt.pkt);
       }
+
+      AVStream *stream = m_pFormatContext->streams[m_pkt.pkt.stream_index];
 
       if (m_program != UINT_MAX)
       {
@@ -1570,4 +1498,80 @@ bool CDVDDemuxFFmpeg::IsProgramChange()
       return true;
   }
   return false;
+}
+
+void CDVDDemuxFFmpeg::GetStreamInfo(AVPacket *pkt)
+{
+  AVStream *st = m_pFormatContext->streams[pkt->stream_index];
+  CDemuxStream *stream = GetStreamInternal(pkt->stream_index);
+
+  // if the stream is new, tell ffmpeg to parse the stream
+  if (!stream && !st->parser)
+  {
+    st->need_parsing = AVSTREAM_PARSE_FULL;
+  }
+
+  // split extradata and decode some info for video streams
+  if(st->parser && st->parser->parser->split && !st->codec->extradata)
+  {
+    int i = st->parser->parser->split(st->codec, pkt->data, pkt->size);
+    if (i > 0 && i < FF_MAX_EXTRADATA_SIZE)
+    {
+      // Found extradata, fill it in. This will cause
+      // a new stream to be created and used.
+      st->codec->extradata_size = i;
+      st->codec->extradata = (uint8_t*)m_dllAvUtil.av_malloc(st->codec->extradata_size + FF_INPUT_BUFFER_PADDING_SIZE);
+      if (st->codec->extradata)
+      {
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::Read() fetching extradata, extradata_size(%d)", st->codec->extradata_size);
+        memcpy(st->codec->extradata, pkt->data, st->codec->extradata_size);
+        memset(st->codec->extradata + i, 0, FF_INPUT_BUFFER_PADDING_SIZE);
+
+        if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO)
+        {
+          const AVCodec* codec;
+          AVDictionary *thread_opt = NULL;
+          codec = st->codec->codec ? st->codec->codec : m_dllAvCodec.avcodec_find_decoder(st->codec->codec_id);
+          // Force thread count to 1 since the h264 decoder will not extract
+          // SPS and PPS to extradata during multi-threaded decoding
+          m_dllAvUtil.av_dict_set(&thread_opt, "threads", "1", 0);
+          m_dllAvCodec.avcodec_open2(st->codec, codec, &thread_opt);
+
+          // We don't need to actually decode here
+          st->codec->skip_idct = AVDISCARD_ALL;
+          st->codec->skip_frame = AVDISCARD_ALL;
+          st->codec->skip_loop_filter = AVDISCARD_ALL;
+
+          // We are looking for an IDR frame
+          AVFrame picture;
+          memset(&picture, 0, sizeof(AVFrame));
+          picture.pts = picture.pkt_dts = picture.pkt_pts = picture.best_effort_timestamp = AV_NOPTS_VALUE;
+          picture.pkt_pos = -1;
+          picture.key_frame = 1;
+          picture.format = -1;
+
+          int rtn, got_picture = 0;
+          rtn = m_dllAvCodec.avcodec_decode_video2(st->codec, &picture, &got_picture, pkt);
+          if (rtn < 0 || !st->codec->width || st->codec->pix_fmt == PIX_FMT_NONE)
+          {
+            CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::Read() decode failed (return value=%d)", rtn);
+            // Clear the extradata to allow entering this extradata section again
+            m_dllAvUtil.av_free(st->codec->extradata);
+            st->codec->extradata = NULL;
+            st->codec->extradata_size = 0;
+          }
+
+          m_dllAvCodec.avcodec_close(st->codec);
+          m_dllAvUtil.av_dict_free(&thread_opt);
+
+          st->parser->flags = 0;
+        }
+      }
+      else
+      {
+        st->codec->extradata_size = 0;
+      }
+    }
+  }
+
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -127,6 +127,7 @@ protected:
   CDemuxStream* GetStreamInternal(int iStreamId);
   void CreateStreams(unsigned int program = UINT_MAX);
   void DisposeStreams();
+  void GetStreamInfo(AVPacket *pkt);
 
   AVDictionary *GetFFMpegOptionsFromURL(const CURL &url);
   double ConvertTimestamp(int64_t pts, int den, int num);


### PR DESCRIPTION
- some refactoring
- added setting parser flag for ffmpeg
- returning a null packet for a video stream not already parsed is wrong imo, this has to be handled by decoder
